### PR TITLE
Adding gh workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,9 +40,7 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-nimble-
         if: runner.os != 'Windows'
 
-      # use prebuilt macos from homebrew for now, then switch
-      # to `nim-lang/setup-nimble-action`
-      - uses: georgelemon/setup-nim-action@master
+      - uses: nim-lang/setup-nimble-action
         with:
           nim-version: ${{ env.NIM_VERSION }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,10 @@ jobs:
 
       - name: Install OpenSSL (macOS)
         if: runner.os == 'macOS'
-        run: brew install openssl
+        run: |
+          brew install openssl
+          echo "LDFLAGS=-L$(brew --prefix openssl)/lib" >> $GITHUB_ENV
+          echo "CPPFLAGS=-I$(brew --prefix openssl)/include" >> $GITHUB_ENV
 
       - name: Cache nimble
         id: cache-nimble
@@ -42,7 +45,8 @@ jobs:
         with:
           nim-version: ${{ env.NIM_VERSION }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-
+      
+      # - run: nimble install nimble # should install latest nimble instead of buggy nimble v0.22.2 that is shipped with nim 2.2.10
       - run: nimble install -y --depsOnly
       - run: nimble build -d:release --out:bin -y
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-nimble-
         if: runner.os != 'Windows'
 
-      - uses: nim-lang/setup-nimble-action
+      - uses: nim-lang/setup-nimble-action@v1
         with:
           nim-version: ${{ env.NIM_VERSION }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,91 @@
+name: release
+on:
+  push:
+    tags:
+      - '*.*.*'
+  workflow_dispatch:
+env:
+  APP_NAME: 'bu'
+  NIM_VERSION: '2.2.10'
+
+jobs:
+  build-artifact:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: macos-14
+            arch: arm64
+          - os: macos-15-intel
+            arch: x86_64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache nimble
+        id: cache-nimble
+        uses: actions/cache@v4
+        with:
+          path: ~/.nimble
+          key: ${{ runner.os }}-${{ runner.arch }}-nim-${{ env.NIM_VERSION }}-nimble-${{ hashFiles('**/*.nimble', '**/nimble.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-nim-${{ env.NIM_VERSION }}-nimble-
+            ${{ runner.os }}-${{ runner.arch }}-nimble-
+        if: runner.os != 'Windows'
+
+      - uses: georgelemon/setup-nim-action@master # use prebuilt macos from homebrew for now, then switch jiro4989/setup-nim-action@master
+        with:
+          nim-version: ${{ env.NIM_VERSION }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: nimble install -y --depsOnly
+      - run: nimble build -y
+
+      - name: Create artifact
+        shell: bash
+        run: |
+          os="${{ runner.os }}"
+          arch="${{ matrix.arch }}"
+          suffix="$os${arch:+-$arch}"
+          assets="${{ env.APP_NAME }}_$(echo "$suffix" | tr '[:upper:]' '[:lower:]')"
+          mkdir -p "dist/$assets"
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            cp bin/clue.exe LICENSE README.md "dist/$assets/"
+            (cd dist && 7z a "$assets.zip" "$assets")
+          else
+            cp bin/clue LICENSE README.md "dist/$assets/"
+            (cd dist && tar czf "$assets.tar.gz" "$assets")
+          fi
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: artifact-${{ matrix.os }}-${{ matrix.arch }}
+          path: dist/*
+
+  release:
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'tag'
+    permissions:
+      contents: write
+    needs:
+      - build-artifact
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: artifact-*
+          path: dist
+          merge-multiple: true
+
+      - name: Create Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --notes "Release" \
+            --draft=false \
+            --prerelease=false \
+            dist/*.tar.gz dist/*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       
       - run: nimble install -y --depsOnly
-      - run: nimble build -d:release --out:bin -y $NIM_PASSL
+      - run: nimble build -d:release --out:./bin/ -y $NIM_PASSL
         shell: bash
 
       - name: Create artifact
@@ -63,7 +63,9 @@ jobs:
             cp bin/*.exe LICENSE README.md "dist/$assets/"
             (cd dist && 7z a "$assets.zip" "$assets")
           else
-            cp bin/* LICENSE README.md "dist/$assets/"
+            find . -maxdepth 1 -type f -perm -u+x -exec cp {} "dist/$assets/" \;
+            find ./bu -maxdepth 1 -type f -perm -u+x -exec cp {} "dist/$assets/" \;
+            cp LICENSE README.md "dist/$assets/"
             (cd dist && tar czf "$assets.tar.gz" "$assets")
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install OpenSSL (macOS)
+        if: runner.os == 'macOS'
+        run: brew install openssl
+
       - name: Cache nimble
         id: cache-nimble
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,13 @@ jobs:
       - name: Install OpenSSL (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew install openssl
-          echo "NIM_PASSL=--passL:-L$(brew --prefix openssl@3)/lib" >> $GITHUB_ENV
+          if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
+            /usr/local/bin/brew install openssl
+            echo "NIM_PASSL=--passL:-L/usr/local/opt/openssl@3/lib" >> $GITHUB_ENV
+          else
+            brew install openssl
+            echo "NIM_PASSL=--passL:-L$(brew --prefix openssl@3)/lib" >> $GITHUB_ENV
+          fi
 
       - name: Cache nimble
         id: cache-nimble

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install openssl
-          echo "LDFLAGS=-L$(brew --prefix openssl)/lib" >> $GITHUB_ENV
-          echo "CPPFLAGS=-I$(brew --prefix openssl)/include" >> $GITHUB_ENV
+          echo "NIM_PASSL=--passL:-L$(brew --prefix openssl@3)/lib" >> $GITHUB_ENV
 
       - name: Cache nimble
         id: cache-nimble
@@ -48,7 +47,8 @@ jobs:
       
       # - run: nimble install nimble # should install latest nimble instead of buggy nimble v0.22.2 that is shipped with nim 2.2.10
       - run: nimble install -y --depsOnly
-      - run: nimble build -d:release --out:bin -y
+      - run: nimble build -d:release --out:bin -y $NIM_PASSL
+        shell: bash
 
       - name: Create artifact
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - run: nimble install -y --depsOnly
-      - run: nimble build -y
+      - run: nimble build -d:release --out:bin -y
 
       - name: Create artifact
         shell: bash
@@ -51,10 +51,10 @@ jobs:
           assets="${{ env.APP_NAME }}_$(echo "$suffix" | tr '[:upper:]' '[:lower:]')"
           mkdir -p "dist/$assets"
           if [[ "${{ runner.os }}" == "Windows" ]]; then
-            cp bin/clue.exe LICENSE README.md "dist/$assets/"
+            cp bin/*.exe LICENSE README.md "dist/$assets/"
             (cd dist && 7z a "$assets.zip" "$assets")
           else
-            cp bin/clue LICENSE README.md "dist/$assets/"
+            cp bin/* LICENSE README.md "dist/$assets/"
             (cd dist && tar czf "$assets.tar.gz" "$assets")
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,13 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-nimble-
         if: runner.os != 'Windows'
 
-      - uses: georgelemon/setup-nim-action@master # use prebuilt macos from homebrew for now, then switch jiro4989/setup-nim-action@master
+      # use prebuilt macos from homebrew for now, then switch
+      # to `nim-lang/setup-nimble-action`
+      - uses: georgelemon/setup-nim-action@master
         with:
           nim-version: ${{ env.NIM_VERSION }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       
-      # - run: nimble install nimble # should install latest nimble instead of buggy nimble v0.22.2 that is shipped with nim 2.2.10
       - run: nimble install -y --depsOnly
       - run: nimble build -d:release --out:bin -y $NIM_PASSL
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           brew install openssl
           echo "NIM_PASSL=--passL:-L$(brew --prefix openssl@3)/lib" >> $GITHUB_ENV
 
-      - uses: nim-lang/setup-nimble-action
+      - uses: nim-lang/setup-nimble-action@v1
         with:
           nim-version: ${{ matrix.nim-version }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install OpenSSL (macOS)
         if: runner.os == 'macOS'
-        run: brew install openssl
+        run: |
+          brew install openssl
+          echo "LDFLAGS=-L$(brew --prefix openssl)/lib" >> $GITHUB_ENV
+          echo "CPPFLAGS=-I$(brew --prefix openssl)/include" >> $GITHUB_ENV
       - uses: jiro4989/setup-nim-action@v2
         with:
           nim-version: ${{ matrix.nim-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           brew install openssl
           echo "NIM_PASSL=--passL:-L$(brew --prefix openssl@3)/lib" >> $GITHUB_ENV
-      - uses: jiro4989/setup-nim-action@v2
+      - uses: georgelemon/setup-nim-action@master # jiro4989/setup-nim-action@v2 # georgelemon/setup-nim-action@master for getting the prebuilt from homebrews
         with:
           nim-version: ${{ matrix.nim-version }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,9 @@ jobs:
           - 'stable'
     steps:
       - uses: actions/checkout@v3
+      - name: Install OpenSSL (macOS)
+        if: runner.os == 'macOS'
+        run: brew install openssl
       - uses: jiro4989/setup-nim-action@v2
         with:
           nim-version: ${{ matrix.nim-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,13 @@ on:
       - examples
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
         nim-version:
           - 'stable'
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,13 @@ jobs:
       - name: Install OpenSSL (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew install openssl
-          echo "NIM_PASSL=--passL:-L$(brew --prefix openssl@3)/lib" >> $GITHUB_ENV
+          if [ "$(uname -m)" = "x86_64" ]; then
+            /usr/local/bin/brew install openssl
+            echo "NIM_PASSL=--passL:-L/usr/local/opt/openssl@3/lib" >> $GITHUB_ENV
+          else
+            brew install openssl
+            echo "NIM_PASSL=--passL:-L$(brew --prefix openssl@3)/lib" >> $GITHUB_ENV
+          fi
 
       - uses: nim-lang/setup-nimble-action@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,7 @@ jobs:
           brew install openssl
           echo "NIM_PASSL=--passL:-L$(brew --prefix openssl@3)/lib" >> $GITHUB_ENV
 
-      # use prebuilt macos from homebrew for now, then switch
-      # to `nim-lang/setup-nimble-action`
-      - uses: georgelemon/setup-nim-action@master
+      - uses: nim-lang/setup-nimble-action
         with:
           nim-version: ${{ matrix.nim-version }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,10 @@ jobs:
         run: |
           brew install openssl
           echo "NIM_PASSL=--passL:-L$(brew --prefix openssl@3)/lib" >> $GITHUB_ENV
-      - uses: georgelemon/setup-nim-action@master # jiro4989/setup-nim-action@v2 # georgelemon/setup-nim-action@master for getting the prebuilt from homebrews
+
+      # use prebuilt macos from homebrew for now, then switch
+      # to `nim-lang/setup-nimble-action`
+      - uses: georgelemon/setup-nim-action@master
         with:
           nim-version: ${{ matrix.nim-version }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
         nim-version:
           - 'stable'
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: test
+on:
+  push:
+    paths-ignore:
+      - LICENSE
+      - README.*
+      - examples
+  pull_request:
+    paths-ignore:
+      - LICENSE
+      - README.*
+      - examples
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        nim-version:
+          - 'stable'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: ${{ matrix.nim-version }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - run: nimble install -Y
+      - run: nimble test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,11 +27,12 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install openssl
-          echo "LDFLAGS=-L$(brew --prefix openssl)/lib" >> $GITHUB_ENV
-          echo "CPPFLAGS=-I$(brew --prefix openssl)/include" >> $GITHUB_ENV
+          echo "NIM_PASSL=--passL:-L$(brew --prefix openssl@3)/lib" >> $GITHUB_ENV
       - uses: jiro4989/setup-nim-action@v2
         with:
           nim-version: ${{ matrix.nim-version }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: nimble install -Y
-      - run: nimble test
+      - run: nimble install -Y $NIM_PASSL
+        shell: bash
+      - run: nimble test $NIM_PASSL
+        shell: bash

--- a/dups.nim
+++ b/dups.nim
@@ -3,16 +3,10 @@ include cligen/unsafeAddr
 import std/[os, posix, strutils, sets, tables, hashes, algorithm],
   cligen/[procpool,mfile,mslice,fileUt,strUt, osUt,posixUt,sysUt, dents,statx]
 
+{.passl: "-lcrypto".}
+
 proc SHA256(i: pointer, n: uint64, o: pointer) {.importc.}
-when defined osx:
-  const so = static:
-    var r = ""
-    for i in countdown(99, 1):
-      let f = "/usr/lib/libcrypto." & $i & ".dylib"
-      if f.fileExists: r = f; break
-    r
-  {.passl: so.}
-else: {.passl: "-lcrypto".}
+
 proc secureHash(x: openArray[char]): array[32, char] =
   SHA256 x[0].unsafeAddr, x.len.uint64, result[0].addr
 


### PR DESCRIPTION
I got carried away and also added a `release.yml` workflow. I think everyone else should have access to this collection, not just nim devs (planning a LLM agentic engine and I think this is a hidden gem for tooling).

`release.yml` has `workflow_dispatch` for testing purposes. Tried to make this work on Windows, but it looks like cligen 1.11.0 can't compile on Windows with Nim 2.x (and bu.nimble requires nim >= 2.0.0) because of:
```
Nim Output C:\Users\runneradmin\.nimble\pkgs2\cligen-1.11.0-15d8930c52fc5822b2b3ea0f5c5f09af2499e446\cligen\mfile.nim(11, 8) Error: undeclared identifier: 'useWinUnicode'
        ... candidates (edit distance, scope distance); see '--spellSuggest': 
        ...  (7, 4): 'OSErrorCode'
       Tip: 603 messages have been suppressed, use --verbose to show them.
vnext.nim(1128)          buildFromDir

    Error:  Build failed for the package: nio 

```

Tried to search for `useWinUnicode` in the stdlibs, can't find it.
