### PR TITLE
WIP GitHub workflows - fixing macos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-nimble-
         if: runner.os != 'Windows'
 
-      - uses: nim-lang/setup-nimble-action@v1
+      - uses: jiro4989/setup-nim-action@v1
         with:
           nim-version: ${{ env.NIM_VERSION }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,17 +15,22 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-        nim-version:
-          - 'stable'
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+            nim-version: 'stable'
+          - os: macos-14
+            arch: arm64
+            nim-version: 'stable'
+          - os: macos-15-intel
+            arch: x86_64
+            nim-version: 'stable'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install OpenSSL (macOS)
         if: runner.os == 'macOS'
         run: |
-          if [ "$(uname -m)" = "x86_64" ]; then
+          if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
             /usr/local/bin/brew install openssl
             echo "NIM_PASSL=--passL:-L/usr/local/opt/openssl@3/lib" >> $GITHUB_ENV
           else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
             echo "NIM_PASSL=--passL:-L$(brew --prefix openssl@3)/lib" >> $GITHUB_ENV
           fi
 
-      - uses: nim-lang/setup-nimble-action@v1
+      - uses: jiro4989/setup-nim-action@v1
         with:
           nim-version: ${{ matrix.nim-version }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- test (macos-15-intel, x86_64, stable) is OK.
- test (macos-14, arm64, stable) NOT. I think the problem is the `nim-lang/setup-nimble-action`, installs a prebuilt x86_64 Nim on all macOS runners

this is wip